### PR TITLE
Add host param

### DIFF
--- a/R/biblioshiny.R
+++ b/R/biblioshiny.R
@@ -17,7 +17,7 @@
 #' 
 #' @export
 
-biblioshiny <- function(port = NULL, launch.browser=TRUE){
-  
-  runApp(system.file("biblioshiny",package="bibliometrix"),launch.browser = launch.browser, port = port)
+biblioshiny <- function(host = "127.0.0.1", port = NULL, launch.browser = TRUE){
+ 
+  runApp(system.file("biblioshiny", package = "bibliometrix"), host = host, port = port, launch.browser = launch.browser)
 }


### PR DESCRIPTION
Hi,

The docker image has been successfully built. But after deploying it to the cluster, it turns out the server listens on 127.0.0.1, thus it cannot be accessed outside the container.

    https://hub.docker.com/r/wuhanstudio/biblioshiny

Do you think it is OK to add another param host, so that it can listen on 0.0.0.0?

I'll rebuild the image and try to deploy it again.

    https://biblioshiny.wuhanstudio.team/

Thanks a lot.