### PR TITLE
Keep app running after session closed

### DIFF
--- a/inst/biblioshiny/server.R
+++ b/inst/biblioshiny/server.R
@@ -2,7 +2,7 @@
 server <- function(input, output, session) {
  
   ## stop the R session
-  session$onSessionEnded(stopApp)
+  # session$onSessionEnded(stopApp)
   ##
   
   ## file upload max size


### PR DESCRIPTION
After running for a while, I notice that the app exits after the session closed (browser closed).

     session$onSessionEnded(stopApp)

If biblioshiny runs on a PC, when the user closes the browser, maybe it means he/she has finished the work and it's reasonable for the app to exit. But maybe it's also OK to leave the app running in case I click on the close button by mistake.

If biblioshiny runs on a server, however, stopping the app after the session closed could cause problems, which means any user closes the session can cause the app exiting and leaving all other users online waiting for the app to restart.

As you can see from the screenshot, the container restarts several times after sessions closed

![image](https://user-images.githubusercontent.com/15157070/76273837-db8acd00-62b9-11ea-8f60-a283de09abeb.png)

I think it is OK to leave the app running after the session is closed which is fine for both PCs and servers. Do you think it is OK to comment this line out?