### PR TITLE
Use "data.frame" as base class

### DIFF
--- a/R/convert2df.R
+++ b/R/convert2df.R
@@ -189,7 +189,7 @@ convert2df<-function(file,dbsource="wos",format="plaintext"){
   row.names(M) <- M$SR
   
   ### bibliometrix>DB class
-  class(M) <- c("data.frame","bibliometrixDB")
+  class(M) <- c("bibliometrixDB", "data.frame")
   
   return(M)
 

--- a/R/histNetwork.R
+++ b/R/histNetwork.R
@@ -210,7 +210,6 @@ scopus <- function(M, min.citations, sep, network, verbose){
   M$LCS[papers] <- LCS
   
   ### HistData
-  class(M)="data.frame"
   histData <- M %>%
     select(.data$SR_FULL, .data$DI, .data$PY, .data$LCS, .data$TC) %>%
     rename(


### PR DESCRIPTION
Fixes #127
Closes r-lib/rlang#1038

This is for compatibility with the tidyverse where we consider it UB to superclass foreign classes. See the data frame section in https://vctrs.r-lib.org/reference/howto-faq-fix-scalar-type-error.html