### PR TITLE
fixing load data error in Shiny app

### DIFF
--- a/inst/biblioshiny/server.R
+++ b/inst/biblioshiny/server.R
@@ -239,13 +239,15 @@ server <- function(input, output, session) {
              },
              ### RData format
              rdata={
-               load(inFile$datapath)
+               var <- load(inFile$datapath)
+               if (var != "M") eval(parse(text = paste0("M <- ", var)))
              },
              rda={
-               load(inFile$datapath)
+               var <- load(inFile$datapath)
+               if (var != "M") eval(parse(text = paste0("M <- ", var)))
              },
              rds={
-               load(inFile$datapath)
+               M <- readRDS(inFile$datapath)
              })
     } else if (is.null(inFile)) {return(NULL)}
     


### PR DESCRIPTION
This commit solves the following bugs:

- error when load a `*.Rds` file
- error when the object in `.Rda` is not named as `M`