### PR TITLE
fixing load data error in Shiny app

### DIFF
--- a/inst/biblioshiny/server.R
+++ b/inst/biblioshiny/server.R
@@ -67,14 +67,14 @@ server <- function(input, output, session) {
       if (n == 1) {
         eval(parse(text = paste0("M <- ", var)))
       } else {
-        stop("I could not find M object in your data file: ", file)
+        stop("I could not find bibliometrixDB object in your data file: ", file)
       }
     }
     rm(list = var[var != "M"])
     if ( ("M" %in% ls()) & inherits(M, "bibliometrixDB") ){
       return(M)
     } else {
-      stop("Please make sure your RData/Rda file contains a M object.")
+      stop("Please make sure your RData/Rda file contains a bibliometrixDB object (M).")
     }
   }
   

--- a/inst/biblioshiny/server.R
+++ b/inst/biblioshiny/server.R
@@ -71,7 +71,7 @@ server <- function(input, output, session) {
       }
     }
     rm(list = var[var != "M"])
-    if ("M" %in% ls() & is.data.frame(M)){
+    if ( ("M" %in% ls()) & inherits(M, "bibliometrixDB") ){
       return(M)
     } else {
       stop("Please make sure your RData/Rda file contains a M object.")

--- a/inst/biblioshiny/server.R
+++ b/inst/biblioshiny/server.R
@@ -60,6 +60,24 @@ server <- function(input, output, session) {
     return(format)
   }
   
+  smart_load <- function(file){
+    var <- load(file)
+    n <- length(var)
+    if (!"M" %in% var){
+      if (n == 1) {
+        eval(parse(text = paste0("M <- ", var)))
+      } else {
+        stop("I could not find M object in your data file: ", file)
+      }
+    }
+    rm(list = var[var != "M"])
+    if ("M" %in% ls() & is.data.frame(M)){
+      return(M)
+    } else {
+      stop("Please make sure your RData/Rda file contains a M object.")
+    }
+  }
+  
   DATAloading<- eventReactive(input$applyLoad,{
     # input$file1 will be NULL initially. After the user selects
     # and uploads a file, it will be a data frame with 'name',
@@ -239,13 +257,13 @@ server <- function(input, output, session) {
              },
              ### RData format
              rdata={
-               load(inFile$datapath)
+               M <- smart_load(inFile$datapath)
              },
              rda={
-               load(inFile$datapath)
+               M <- smart_load(inFile$datapath)
              },
              rds={
-               load(inFile$datapath)
+               M <- readRDS(inFile$datapath)
              })
     } else if (is.null(inFile)) {return(NULL)}
     


### PR DESCRIPTION
This commit solves the following bugs:

- error when load a *.Rds file
- error when the object in .Rda is not named as M

The issue is descripted in #157 .

I just lost in Git/GitHub, and have to create a new PR here and close the previous one.

In this commit, a `smart_load()` function was implemented to deal with the conditions in `load()` data file.

Before return M object, I just check whether it is a data.frame. But I believe this is not safe in most conditions. I suggest you to use a bibliometrix object in the future.