### PR TITLE
Fix failing CI: realign completeMetadata tests with the #628 refactoring

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/R/missingData.R
+++ b/R/missingData.R
@@ -30,7 +30,10 @@ missingData <- function(M) {
     sum(is.na(M[, x]) | M[, x] %in% c("NA,0000,NA", "NA", "", "none"))
   })
 
-  if (sum(as.numeric(M$TC), na.rm = T) == 0) {
+  ## Guard on the column being present: assigning missing_counts["TC"] when the
+  ## collection has no TC column would append a 6th element to a 5-element
+  ## vector and break the data.frame() below.
+  if ("TC" %in% cols && sum(as.numeric(M$TC), na.rm = T) == 0) {
     missing_counts["TC"] <- nrow(M)
   }
   # calculate the percentage of missing values in each column

--- a/tests/testthat/test-completeMetadata.R
+++ b/tests/testthat/test-completeMetadata.R
@@ -108,7 +108,7 @@ test_that(".merge_enrichment fills only missing cells and records provenance", {
     stringsAsFactors = FALSE
   )
   enriched <- list(
-    by_doi = list(
+    by_key = list(
       "10.1234/a" = list(DI = "10.1234/a",
                       AB = "new abstract A",
                       TI = "new title A",
@@ -153,7 +153,7 @@ test_that(".merge_enrichment is a no-op when nothing is missing", {
     stringsAsFactors = FALSE
   )
   enriched <- list(
-    by_doi = list("10.1234/a" = list(DI = "10.1234/a",
+    by_key = list("10.1234/a" = list(DI = "10.1234/a",
                                   AB = "x", TI = "y")),
     fail_count = 0L
   )
@@ -192,27 +192,49 @@ test_that("completeMetadata short-circuits when no eligible records", {
 
 # ----- Phase 2: OpenAlex source -----------------------------------------------
 
-test_that("completeMetadata auto-disables OpenAlex when M$DB is OPENALEX", {
-  ## We construct a one-row collection with DB=OPENALEX and a DOI that
-  ## triggers eligibility. With sources=c("openalex","crossref") and an
-  ## offline-impossible Crossref endpoint, we just verify that we DO NOT
-  ## crash on missing openalexR network and that the function attempts only
-  ## Crossref. We block real traffic by setting fields to ones the local
-  ## fallback path can short-circuit.
+test_that("completeMetadata queries OpenAlex collections by Work ID", {
+  ## Historical behaviour auto-disabled the OpenAlex pass whenever M$DB was
+  ## OPENALEX. That is wrong for partial OpenAlex CSV web exports, which carry
+  ## only the columns the user selected: re-querying OpenAlex is exactly what
+  ## fills the omitted fields. The pass now runs, and is keyed by the OpenAlex
+  ## Work ID (id_oa) whenever the collection carries one -- the DOI may be
+  ## absent from a minimal export.
   M <- data.frame(
-    SR = "a",
-    DI = "10.1234/anything",
+    SR = c("a", "b"),
+    DI = c(NA_character_, "10.1234/anything"),
+    id_oa = c("https://openalex.org/W123", "W456"),
     AB = NA_character_,
     DB = "OPENALEX",
-    TC = "0",
     stringsAsFactors = FALSE
   )
-  ## Use sources = "openalex" alone -> auto-disabled -> empty source set ->
-  ## function returns the original collection unchanged with empty report.
+
+  ns <- asNamespace("bibliometrix")
+  orig_oa <- get(".enrich_from_openalex", envir = ns)
+  try(unlockBinding(".enrich_from_openalex", ns), silent = TRUE)
+  on.exit(assign(".enrich_from_openalex", orig_oa, envir = ns), add = TRUE)
+
+  ## Stub the client so the test stays offline and we can inspect the key
+  ## vector the function chose to look records up by.
+  seen <- NULL
+  assign(".enrich_from_openalex",
+         function(keys, fields, email, oa_apikey,
+                  key_type = c("doi", "id"),
+                  progress = NULL, verbose = TRUE) {
+           seen <<- list(keys = keys, key_type = match.arg(key_type))
+           list(by_key = list("W123" = list(AB = "AB from OA")),
+                fail_count = 0L)
+         },
+         envir = ns)
+
   res <- completeMetadata(M, sources = "openalex",
-                          fields = c("AB","TC"), verbose = FALSE)
-  expect_identical(res$M, M)
-  expect_equal(nrow(res$report), 0L)
+                          fields = "AB", verbose = FALSE)
+
+  ## Work IDs, not DOIs -- row 'a' has no DOI at all and must still be queried.
+  expect_equal(seen$key_type, "id")
+  expect_setequal(seen$keys, c("W123", "W456"))
+  expect_equal(res$M$AB[1], "AB from OA")
+  expect_true(is.na(res$M$AB[2]))
+  expect_equal(unique(res$report$source), "openalex")
 })
 
 test_that("completeMetadata silently drops TC when only Crossref is selected", {
@@ -354,7 +376,7 @@ test_that("completeMetadata report aggregates rows per source", {
          function(dois, fields, email, batch_size = 20,
                   progress = NULL, verbose = TRUE) {
            list(
-             by_doi = list(
+             by_key = list(
                "10.1234/aaa" = list(DI = "10.1234/aaa", TI = "T from CR"),
                "10.1234/bbb" = list(DI = "10.1234/bbb", AB = "AB from CR")
              ),
@@ -363,10 +385,11 @@ test_that("completeMetadata report aggregates rows per source", {
          },
          envir = ns)
   assign(".enrich_from_openalex",
-         function(dois, fields, email, oa_apikey,
+         function(keys, fields, email, oa_apikey,
+                  key_type = c("doi", "id"),
                   progress = NULL, verbose = TRUE) {
            list(
-             by_doi = list(
+             by_key = list(
                "10.1234/aaa" = list(DI = "10.1234/aaa",
                                     AB = "AB from OA",
                                     TC = "42")


### PR DESCRIPTION
R CMD check has been red since 10677dc (Issue #628), which refactored the metadata enrichment layer without updating its tests:

- .enrich_from_crossref()/.enrich_from_openalex() now return `by_key` (DOI or OpenAlex Work ID) instead of `by_doi`. The tests still built `by_doi`, so .merge_enrichment() short-circuited and filled nothing.
- .enrich_from_openalex() gained a `key_type` argument; the test stub still had the old signature and failed with "unused argument".
- The "auto-disable OpenAlex when M$DB is OPENALEX" behaviour was intentionally removed (partial OpenAlex CSV exports must be re-queried). The test asserting it has been rewritten to cover the new contract: lookup by id_oa with key_type = "id", with the client stubbed so the test stays offline instead of issuing a real OpenAlex request.

Also fixes a latent crash in missingData(): missing_counts["TC"] was assigned even when the collection has no TC column (sum(as.numeric(NULL)) is 0), appending an extra element to the vector and breaking the subsequent data.frame() call.

Full suite: 222 pass, 0 fail.