### PR TITLE
fix(convert2df): fix typo 'dimneisons' to 'dimensions' in duplicate removal switch

### DIFF
--- a/R/convert2df.R
+++ b/R/convert2df.R
@@ -301,7 +301,7 @@ convert2df <- function(
       openalex_api = {
         id_field <- "id_oa"
       },
-      dimneisons = {
+      dimensions = {
         id_field <- "UT"
       },
       pubmed = {


### PR DESCRIPTION
### Description
Fixes a typo in `R/convert2df.R` (line 304) where `dbsource` was matched as `dimneisons` instead of `dimensions` inside the `switch()` block for duplicate document filtering (`remove.duplicates = TRUE`).

### Impact
Before this fix, calling `convert2df(..., dbsource = "dimensions", remove.duplicates = TRUE)` failed to match the `dimensions` source in the switch statement. Consequently, duplicate removal defaulted to matching by Title (`TI`) instead of the Dimensions document unique identifier (`UT`).

### Changes
* Fixed typo `dimneisons` -> `dimensions` in [`R/convert2df.R#L304`](file:///R/convert2df.R#L304).