### PR TITLE
Write down how to contribute, and ask bug reports for a traceback (#659)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something in bibliometrix or Biblioshiny does not work as documented
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. The two fields that decide whether an issue can be
+        acted on are the **verbatim traceback** and the output of
+        **`sessionInfo()`**. Please paste what the console printed, unedited --
+        a description written after the fact, by you or by an AI assistant, is
+        not enough to locate a fault.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Code that reproduces it
+      description: >
+        The smallest sequence of calls that shows the problem. If it is a
+        Biblioshiny problem, name the page and the control you used instead.
+      render: r
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: The error, verbatim, and the traceback
+      description: >
+        The error message exactly as printed, followed by the output of
+        `traceback()` run in the same session right after the error.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: session-info
+    attributes:
+      label: Output of sessionInfo()
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database and export format
+      description: Most defects are specific to one importer.
+      options:
+        - Web of Science (plaintext)
+        - Web of Science (BibTeX)
+        - Scopus (CSV)
+        - Scopus (BibTeX)
+        - OpenAlex (CSV)
+        - OpenAlex (API)
+        - PubMed
+        - Lens.org
+        - Dimensions
+        - Cochrane
+        - Several, merged
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: data
+    attributes:
+      label: The collection
+      description: >
+        A handful of records that reproduce the problem is far more useful than
+        a full export. If the data cannot be shared, say so and describe its
+        shape: how many documents, and which fields are present or empty.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation and function reference
+    url: https://www.bibliometrix.org
+    about: Guides for bibliometrix and Biblioshiny, and the reference of every function.
+  - name: The bibliometrix book
+    url: https://book.bibliometrix.org
+    about: >
+      Worked science mapping analyses. Questions about how to perform an
+      analysis are usually answered here rather than by an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an analysis, an option or an improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: >
+        Describe the analysis you want to perform and why the current functions
+        do not support it. The scientific motivation matters more than the
+        implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you have in mind
+      description: >
+        The function, argument or Biblioshiny control you would expect, and what
+        it would return. References to the literature are welcome.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you do instead today
+      description: The workaround you are using, if any.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Please target the `develop` branch. `master` is the release branch and only
+receives merges from `develop`. See CONTRIBUTING.md.
+-->
+
+## What this changes
+
+<!-- One defect or one feature per pull request. -->
+
+## Before and after
+
+<!--
+The behaviour you observed before the change and after it, with the actual
+output of both. Every claim in a pull request is verified here, so a
+reproduction saves a round trip.
+-->
+
+```r
+# before
+
+# after
+```
+
+## Checklist
+
+- [ ] The pull request targets `develop`
+- [ ] `testthat::test_dir("tests/testthat")` is green, with no failures
+- [ ] A regression test covers the change
+- [ ] `NEWS` and `NEWS.md` have an entry under the development version
+- [ ] `R/`, `inst/biblioshiny/` and `NEWS` are still pure ASCII
+- [ ] No unrelated reformatting in the diff

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Rubbish
 desktop.ini
 vignette.txt
 HANDOFF.md
+tasks/
 .claude
 .positai
 inst/doc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to bibliometrix
+
+Thanks for taking the time to contribute. bibliometrix is maintained by a small
+academic team, and well-prepared reports and pull requests are what make it
+possible to keep up.
+
+This file records the conventions of this repository. Most of them are not
+guessable from the outside, so please read the section that applies to you
+before you start.
+
+- [Reporting a bug](#reporting-a-bug)
+- [Suggesting a feature](#suggesting-a-feature)
+- [Sending a pull request](#sending-a-pull-request)
+- [Setting up a development environment](#setting-up-a-development-environment)
+- [Conventions of this repository](#conventions-of-this-repository)
+
+## Reporting a bug
+
+Open an issue with the **Bug report** template. The two fields that decide
+whether an issue can be acted on are:
+
+1. **The verbatim traceback.** Run `traceback()` in the same session, right
+   after the error, and paste what it prints, unedited.
+2. **The output of `sessionInfo()`**, so we know your R version, your platform
+   and the versions of the packages actually loaded.
+
+Please paste what the console printed rather than a description or a
+reconstruction of it. A summary written after the fact, by you or by an AI
+assistant, is not enough to locate a fault: we have open issues that cannot be
+diagnosed because the reported call stack does not correspond to any code path
+in the package, and there is nothing we can do with them until the real output
+arrives.
+
+Also tell us:
+
+- the **database and export format** you imported (Web of Science plaintext,
+  Scopus CSV, OpenAlex CSV, PubMed, Lens, Dimensions, ...), since the importers
+  differ and most defects are specific to one of them;
+- the **smallest collection that reproduces it**. A handful of records is far
+  more useful than a full export. If the data cannot be shared, say so and
+  describe its shape (number of documents, which fields are present or empty).
+
+If the problem is in Biblioshiny, say which page and which control you used.
+
+## Suggesting a feature
+
+Open an issue with the **Feature request** template. Describe the analysis you
+are trying to perform and why the current functions do not support it. Feature
+requests are welcome but are scheduled against a small maintenance budget, so a
+clear scientific motivation helps a great deal.
+
+## Sending a pull request
+
+**Target the `develop` branch.** `master` is the release branch: it is
+protected, and it only ever receives merges from `develop`. A pull request
+opened against `master` cannot be merged the normal way, and when one is merged
+anyway the change has to be brought back into `develop` by hand.
+
+So: fork the repository, branch off `develop`, and open the pull request against
+`develop`.
+
+Before you open it:
+
+- **Reproduce the failure first, and keep the reproduction.** State in the pull
+  request what the behaviour was before your change and what it is after, with
+  the actual output of both. A claim that a change fixes something is not
+  useful on its own; we verify every one of them, and a claim that does not
+  reproduce costs more time than the fix saves.
+- **Run the test suite** and make sure it is green:
+
+  ```r
+  pkgload::load_all(".")
+  testthat::test_dir("tests/testthat")
+  ```
+
+  There must be no failures. The suite writes `tests/testthat/Rplots.pdf` as a
+  side effect; delete it rather than committing it.
+- **Add a regression test** for the defect you fixed, in the file that covers
+  the function you touched.
+- **Add an entry to `NEWS` and to `NEWS.md`**, under the development version
+  heading, saying what was wrong and what changed.
+- **Keep the change to one defect.** A pull request that fixes one thing is
+  reviewed in an hour; one that fixes four unrelated things in three files
+  waits.
+- **Do not reformat code you are not changing.** A whitespace sweep hides the
+  actual change in the diff.
+
+Note on continuous integration: `R-CMD-check` currently runs on pushes to
+`master` and on pull requests whose base is `master`. A pull request against
+`develop` therefore gets no automated check, and running the suite locally is
+the only signal you will have.
+
+## Setting up a development environment
+
+bibliometrix requires R >= 3.5.0 and has a large set of dependencies.
+
+```r
+install.packages(c("devtools", "pkgload", "testthat"))
+devtools::install_deps(dependencies = TRUE)
+
+pkgload::load_all(".")                       # load the package from source
+testthat::test_dir("tests/testthat")         # run the tests
+devtools::check()                            # full R CMD check, slower
+```
+
+To work on Biblioshiny, load the package and run `biblioshiny()`. The app
+sources live in `inst/biblioshiny/`.
+
+## Conventions of this repository
+
+- **`R/`, `inst/biblioshiny/` and `NEWS` must stay pure ASCII.** Non-ASCII
+  characters in the Biblioshiny sources break the app in non-UTF-8 locales, and
+  a test enforces it. Write them as `\u` escapes, or as numeric character
+  references in HTML. `NEWS.md` is exempt.
+- **Every user-visible change gets a `NEWS` entry.** Entries here are written to
+  explain the defect, not just to name it: what went wrong, in which situation,
+  and what the reader will now see instead.
+- **Match the style of the code around you.** The package mixes base R and
+  tidyverse idioms depending on the file; follow the file you are in.
+- **Comments explain why, not what.** A comment that restates the code adds
+  nothing; one that records the reason a guard exists prevents it from being
+  removed later.
+
+## Licence
+
+bibliometrix is released under GPL-3. By contributing you agree that your
+contribution is licensed under the same terms.


### PR DESCRIPTION
Closes #659.

The repository carried no `CONTRIBUTING.md`, no issue templates and no pull request template, so the **Contribute** button sent people to `opensource.guide` and none of the conventions of this repository were discoverable from the outside.

These files are read by GitHub from the default branch only, which is why this goes to `master`.

## What is added

**`CONTRIBUTING.md`** — the conventions that cannot be guessed:

- branch from `develop` and target `develop`; `master` is the protected release branch. Both community pull requests opened this week targeted `master`, and #660 had to be back-merged into `develop` by hand afterwards;
- how to set up and run the suite, and that it writes `tests/testthat/Rplots.pdf` as a side effect;
- that `R-CMD-check` runs on pushes to `master` and on pull requests whose base is `master`, so a pull request against `develop` gets no automated signal and the local run is the only one;
- `R/`, `inst/biblioshiny/` and `NEWS` must stay pure ASCII, and why;
- an entry in `NEWS` and `NEWS.md` is expected;
- a claim that a change fixes something is verified here, so it needs a reproduction with the output before and after.

**`.github/ISSUE_TEMPLATE/bug_report.yml`** — requires the verbatim error, the output of `traceback()`, `sessionInfo()`, and the database and export format, and asks for the smallest collection that reproduces the problem. It says explicitly that a description of the error written after the fact, by a person or by an AI assistant, is not enough. #655 has been blocked on exactly that since August.

**`.github/ISSUE_TEMPLATE/feature_request.yml`**, **`config.yml`** (links to bibliometrix.org and book.bibliometrix.org, both checked) and **`.github/PULL_REQUEST_TEMPLATE.md`** with a checklist matching the above.

## Notes

No R code is touched. `.github/` and root `.md` files are already in `.Rbuildignore`, so the package build is unaffected. The YAML of the three forms parses.

Suggested by @GabrielBaiano in #659.
