### PR TITLE
Say where each kind of question belongs (#665)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,3 +8,9 @@ contact_links:
     about: >
       Worked science mapping analyses. Questions about how to perform an
       analysis are usually answered here rather than by an issue.
+  - name: Questions about using bibliometrix
+    url: https://github.com/massimoaria/bibliometrix/blob/master/SUPPORT.md
+    about: >
+      Running an analysis, choosing an indicator, reading a result: these go to
+      info@bibliometrix.org rather than to an issue. SUPPORT.md says where each
+      kind of question belongs.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,62 @@
+# Getting help with bibliometrix
+
+Which channel to use depends on what kind of answer you need. They do not
+overlap, and picking the right one is usually the difference between getting an
+answer and not getting one.
+
+## A question about how to use bibliometrix
+
+Read the documentation, then write to **info@bibliometrix.org**.
+
+- [bibliometrix.org](https://www.bibliometrix.org) — guides for bibliometrix and
+  Biblioshiny, and the reference of every function.
+- [The bibliometrix book](https://book.bibliometrix.org) — worked science
+  mapping analyses, end to end. Most questions of the form *how do I ...* are
+  answered there.
+- The vignettes:
+  [Introduction to bibliometrix](https://www.bibliometrix.org/vignettes/Introduction_to_bibliometrix.html)
+  and
+  [Data importing and converting](https://www.bibliometrix.org/vignettes/Data-Importing-and-Converting.html).
+
+`info@bibliometrix.org` is the address the package prints when you load it, and
+it is the right place for questions about running an analysis, choosing an
+indicator, or reading a result.
+
+Please do not open an issue for these. The tracker is read as a list of defects
+to fix, so a usage question placed there is worse for both sides: it waits
+behind bugs, and it makes the list of real defects harder to see.
+
+## Something in the package is broken
+
+Open an issue with the **Bug report** template.
+[`CONTRIBUTING.md`](CONTRIBUTING.md#reporting-a-bug) says in full what makes a
+report actionable. The short version: the verbatim error, the output of
+`traceback()` run in the same session right after it, the output of
+`sessionInfo()`, and the database and export format you imported.
+
+Paste what the console printed rather than a description of it. A summary
+written after the fact, by you or by an AI assistant, is not enough to locate a
+fault, and we have open issues that cannot be diagnosed for exactly that reason.
+
+## Something is missing
+
+Open an issue with the **Feature request** template. Describe the analysis you
+are trying to perform and why the current functions do not support it.
+
+## You would like to fix or add it yourself
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md). It records the conventions of this
+repository — which branch to target, how to run the suite, what a pull request
+needs — most of which are not guessable from the outside.
+
+## What we cannot do
+
+bibliometrix is maintained by a small academic team, alongside the rest of our
+work. We cannot design your study, choose your methods for you, or run your
+analysis. Questions about the software we will answer; questions about your
+research are for your supervisor, your co-authors and your reviewers.
+
+## Reporting something else
+
+Conduct that breaches the [Code of Conduct](CODE_OF_CONDUCT.md), and anything
+that needs to stay private, goes to aria@unina.it.


### PR DESCRIPTION
## What this changes

Closes #665, which asked for GitHub Discussions.

Discussions is not enabled. The argument for it was that open-ended threads clutter the issue tracker, and that does not describe this repository: 43 issues opened in the last twelve months by 32 different people, and reading their titles they are all bug reports or feature requests. #665 is itself the only meta thread of the year. A tracker at roughly three issues a month, all actionable, is not congested, and a second inbox next to it would be one more place for a question to sit unanswered — which reads worse than not having the tab at all. The decision is also reversible at no cost: an issue can be converted into a discussion later, so if usage questions do start arriving, it can be turned on then, with evidence.

What the repository was actually missing is the routing. `R/zzz.R:309` prints `info@bibliometrix.org` on load, but nothing here said that usage questions go to that address and defects go to the tracker, so an issue was the only door a visitor could see.

- **`SUPPORT.md`** says where each kind of question belongs: usage to the documentation and then to `info@bibliometrix.org`, defects and feature requests to the tracker with the forms, contributions to `CONTRIBUTING.md`, Code of Conduct matters to `aria@unina.it`. It also says what we cannot do, which is design a study or run someone's analysis.
- **`.github/ISSUE_TEMPLATE/config.yml`** links to it from the new-issue chooser, next to the website and the book — the moment at which someone is deciding where to write.

The two other points of #665 — commit strategy, and how to spell accented names under the ASCII rule — are the questions from #659 and were answered in #669.

No `NEWS` entry: nothing in the package changed. `SUPPORT.md` is covered by the existing `^[^/]*\.md$` line of `.Rbuildignore`, so it stays out of the build.
