### PR TITLE
Generate CITATION.cff from the package metadata (#671)

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -1,0 +1,70 @@
+# Keeps CITATION.cff in step with DESCRIPTION and inst/CITATION, which is what
+# GitHub reads for the "Cite this repository" button (issue #671).
+#
+# It runs on `develop` and not on `master`: `master` requires a pull request, so
+# a push from GITHUB_TOKEN is rejected there. The regenerated file reaches
+# `master` with the next develop -> master merge, like every other change.
+on:
+  push:
+    branches: [develop]
+    paths:
+      - DESCRIPTION
+      - inst/CITATION
+      - .github/workflows/update-citation-cff.yaml
+  workflow_dispatch:
+
+name: Update CITATION.cff
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-citation-cff
+  cancel-in-progress: false
+
+jobs:
+  update-citation-cff:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      # `packages` replaces the default `deps::.`, so the package's own ~40
+      # dependencies are not installed: cffr reads DESCRIPTION and inst/CITATION
+      # as files and needs neither the package nor its dependencies.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: any::cffr
+
+      - name: Regenerate CITATION.cff
+        shell: Rscript {0}
+        run: |
+          # dependencies = FALSE: with TRUE every Imports entry is added as a
+          # `references` item, 42 of them, burying the three works that matter.
+          # `message` keeps the citHeader() wording of inst/CITATION.
+          # cff_write() validates against the CFF 1.2.0 schema and errors if the
+          # result is not valid, so a bad DESCRIPTION fails the job here.
+          cffr::cff_write(
+            "DESCRIPTION",
+            dependencies = FALSE,
+            keys = list(message = "To cite bibliometrix in publications, please use:")
+          )
+
+      - name: Commit if it changed
+        run: |
+          if git diff --quiet -- CITATION.cff; then
+            echo "CITATION.cff is already in step with DESCRIPTION and inst/CITATION."
+            exit 0
+          fi
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CITATION.cff
+          git commit -m "Regenerate CITATION.cff from DESCRIPTION and inst/CITATION"
+          git push origin HEAD:develop

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,82 +1,120 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
 cff-version: 1.2.0
-message: "To cite bibliometrix in publications, please use the article below. The package ships the full list of citable works in inst/CITATION, which citation(\"bibliometrix\") prints in R."
-title: "bibliometrix: Comprehensive Science Mapping Analysis"
+message: 'To cite bibliometrix in publications, please use:'
 type: software
+license: GPL-3.0-only
+title: 'bibliometrix: Comprehensive Science Mapping Analysis'
+version: 5.5.0.9000
+doi: 10.1016/j.joi.2017.08.007
+identifiers:
+- type: doi
+  value: 10.32614/CRAN.package.bibliometrix
+- type: url
+  value: https://www.k-synth.com
+abstract: Tool for quantitative research in scientometrics and bibliometrics. It implements
+  the comprehensive workflow for science mapping analysis proposed in Aria M. and
+  Cuccurullo C. (2017) <https://doi.org/10.1016/j.joi.2017.08.007>. 'bibliometrix'
+  provides various routines for importing bibliographic data from 'SCOPUS', 'Clarivate
+  Analytics Web of Science' (<https://www.webofknowledge.com/>), 'Digital Science
+  Dimensions' (<https://www.dimensions.ai/>), 'OpenAlex' (<https://openalex.org/>),
+  'Cochrane Library' (<https://www.cochranelibrary.com/>), 'Lens' (<https://www.lens.org/>),
+  and 'PubMed' (<https://pubmed.ncbi.nlm.nih.gov/>) databases, performing bibliometric
+  analysis and building networks for co-citation, coupling, scientific collaboration
+  and co-word analysis.
 authors:
+- family-names: Aria
+  given-names: Massimo
+  email: aria@unina.it
+  orcid: https://orcid.org/0000-0002-8517-9411
+- family-names: Cuccurullo
+  given-names: Corrado
+  email: cuccurullocorrado@gmail.com
+  orcid: https://orcid.org/0000-0002-7401-8575
+preferred-citation:
+  type: article
+  title: 'bibliometrix: An R-tool for comprehensive science mapping analysis'
+  authors:
   - family-names: Aria
     given-names: Massimo
     email: aria@unina.it
-    orcid: "https://orcid.org/0000-0002-8517-9411"
-    affiliation: "University of Naples Federico II"
+    orcid: https://orcid.org/0000-0002-8517-9411
   - family-names: Cuccurullo
     given-names: Corrado
     email: cuccurullocorrado@gmail.com
-    orcid: "https://orcid.org/0000-0002-7401-8575"
-    affiliation: "University of Campania Luigi Vanvitelli"
-abstract: "Tool for quantitative research in scientometrics and bibliometrics. It implements the comprehensive workflow for science mapping analysis proposed in Aria M. and Cuccurullo C. (2017), imports bibliographic data from Scopus, Clarivate Analytics Web of Science, Digital Science Dimensions, OpenAlex, Cochrane Library, Lens and PubMed, performs bibliometric analysis and builds networks for co-citation, coupling, scientific collaboration and co-word analysis."
-keywords:
-  - bibliometrics
-  - scientometrics
-  - science-mapping
-  - bibliometric-analysis
-  - co-citation
-  - co-word-analysis
-  - biblioshiny
-  - r
-license: GPL-3.0-only
-version: 5.5.0
-date-released: "2026-08-29"
-url: "https://www.bibliometrix.org"
-repository-code: "https://github.com/massimoaria/bibliometrix"
-repository-artifact: "https://CRAN.R-project.org/package=bibliometrix"
-preferred-citation:
-  type: article
-  title: "bibliometrix: An R-tool for comprehensive science mapping analysis"
-  authors:
-    - family-names: Aria
-      given-names: Massimo
-      orcid: "https://orcid.org/0000-0002-8517-9411"
-    - family-names: Cuccurullo
-      given-names: Corrado
-      orcid: "https://orcid.org/0000-0002-7401-8575"
-  journal: "Journal of Informetrics"
-  year: 2017
-  volume: 11
-  issue: 4
-  start: 959
-  end: 975
-  doi: "10.1016/j.joi.2017.08.007"
+    orcid: https://orcid.org/0000-0002-7401-8575
+  journal: Journal of Informetrics
+  year: '2017'
+  volume: '11'
+  issue: '4'
   publisher:
     name: Elsevier
+  doi: 10.1016/j.joi.2017.08.007
+  start: '959'
+  end: '975'
+repository: https://CRAN.R-project.org/package=bibliometrix
+repository-code: https://github.com/massimoaria/bibliometrix
+url: https://www.bibliometrix.org
+contact:
+- family-names: Aria
+  given-names: Massimo
+  email: aria@unina.it
+  orcid: https://orcid.org/0000-0002-8517-9411
+keywords:
+- bibliometric-analysis
+- bibliometrics
+- citation
+- citation-network
+- citations
+- co-authors
+- co-occurence
+- co-word-analysis
+- correspondence-analysis
+- coupling
+- isi-web
+- journal
+- manuscript
+- quantitative-analysis
+- scholars
+- science
+- science-mapping
+- scientific
+- scientometrics
+- scopus
 references:
-  - type: article
-    title: "Biblioshiny and the SAAS Workflow: An integrated framework for transparent and reproducible science mapping. A demonstration through the replication of a study"
-    authors:
-      - family-names: Aria
-        given-names: Massimo
-        orcid: "https://orcid.org/0000-0002-8517-9411"
-      - family-names: Cuccurullo
-        given-names: Corrado
-        orcid: "https://orcid.org/0000-0002-7401-8575"
-      - family-names: D'Aniello
-        given-names: Luca
-      - family-names: Spano
-        given-names: Maria
-    journal: "Journal of Informetrics"
-    year: 2026
-    doi: "10.1016/j.joi.2026.101837"
-    publisher:
-      name: Elsevier
-  - type: book
-    title: "Science Mapping Analysis - A primer with Biblioshiny"
-    authors:
-      - family-names: Aria
-        given-names: Massimo
-        orcid: "https://orcid.org/0000-0002-8517-9411"
-      - family-names: Cuccurullo
-        given-names: Corrado
-        orcid: "https://orcid.org/0000-0002-7401-8575"
-    year: 2026
-    isbn: "978-88-386-2297-7"
-    publisher:
-      name: McGraw-Hill
+- type: article
+  title: 'Biblioshiny and the SAAS Workflow: An integrated framework for transparent
+    and reproducible science mapping. A demonstration through the replication of a
+    study'
+  authors:
+  - family-names: Aria
+    given-names: Massimo
+  - family-names: Cuccurullo
+    given-names: Corrado
+  - family-names: D'Aniello
+    given-names: Luca
+  - family-names: Spano
+    given-names: Maria
+  journal: Journal of Informetrics
+  year: '2026'
+  volume: '20'
+  issue: '3'
+  publisher:
+    name: Elsevier
+  doi: 10.1016/j.joi.2026.101837
+  start: '101837'
+- type: book
+  title: Science Mapping Analysis - A primer with Biblioshiny
+  authors:
+  - family-names: Aria
+    given-names: Massimo
+  - family-names: Cuccurullo
+    given-names: Corrado
+  publisher:
+    name: McGraw-Hill
+  year: '2026'
+  isbn: 978-88-386-2297-7
+

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -5,6 +5,10 @@ bibentry(bibtype="Article",
          author = "Massimo Aria and Corrado Cuccurullo",
          journal = "Journal of Informetrics",
          year = "2017",
+         volume = "11",
+         number = "4",
+         pages = "959--975",
+         publisher = "Elsevier",
          doi = "10.1016/j.joi.2017.08.007",
          textVersion =
            paste("Aria, M., & Cuccurullo, C. (2017),",
@@ -16,12 +20,16 @@ bibentry(bibtype="Article",
          author = "Massimo Aria and Corrado Cuccurullo and Luca D'Aniello and Maria Spano",
          journal = "Journal of Informetrics",
          year = "2026",
+         volume = "20",
+         number = "3",
+         pages = "101837",
+         publisher = "Elsevier",
          doi = "10.1016/j.joi.2026.101837",
          textVersion =
            paste("Aria, M., Cuccurullo, C., D'Aniello, L., & Spano, M. (2026),",
            "Biblioshiny and the SAAS Workflow: An integrated framework for transparent and reproducible science mapping.",
            "A demonstration through the replication of a study,",
-           "Journal of Informetrics, DOI: 10.1016/j.joi.2026.101837."))
+           "Journal of Informetrics, 20(3), 101837, Elsevier."))
 
 bibentry(bibtype="Book",
          title = "Science Mapping Analysis - A primer with Biblioshiny",


### PR DESCRIPTION
Follow-up to #672. That pull request made the *Cite this repository* button work; this one removes the maintenance it left behind.

**The problem with the hand-written file.** `DESCRIPTION`, `inst/CITATION` and `CITATION.cff` were three places stating the same facts, and the `version` field would have gone stale at the first release with nothing to bump it.

**What changed**

- `CITATION.cff` is now the output of `cffr::cff_write()`, which reads `DESCRIPTION` and `inst/CITATION` and takes the keywords from the repository topics. Against the hand-written file it gains the CRAN DOI, the CRAN repository, the maintainer contact and 20 keywords instead of 8.
- `inst/CITATION` records `volume`, `number` and `pages` for both articles. They were stated only inside `textVersion`, where nothing can read them, so `toBibtex()` and every parser got a reference with no pagination; the 2026 entry did not state them at all. Values from Crossref: 11(4), 959-975 and 20(3), 101837. The printed citation is unchanged for the entries that have a `textVersion`.
- `.github/workflows/update-citation-cff.yaml` regenerates the file whenever `DESCRIPTION` or `inst/CITATION` changes.

**Two non-default arguments, both deliberate**

- `dependencies = FALSE` — with `TRUE`, every `Imports` entry becomes a `references` item. Measured: **42 references** instead of 3, burying the works that matter.
- `keys = list(message = ...)` — restores the `citHeader()` wording of `inst/CITATION` in place of the generic line cffr writes.

**Why the workflow runs on `develop` and not on `master`.** `master` requires a pull request, so a push from `GITHUB_TOKEN` is rejected there. The regenerated file reaches `master` with the next merge, like every other change.

**Checks**

- The workflow already ran on the push to `develop` ([run 34527920597](https://github.com/massimoaria/bibliometrix/actions/runs/34527920597)): green, and it reported *"CITATION.cff is already in step"* — the committed file is byte-identical to what CI produces. It installs only cffr, not the package's ~40 dependencies, and finishes in about 90 seconds.
- Valid against the [CFF 1.2.0 schema](https://citation-file-format.github.io/1.2.0/schema.json).
- `R CMD build`: the tarball carries `inst/CITATION` and not `CITATION.cff`.
- `[ FAIL 0 | WARN 0 | SKIP 8 | PASS 411 ]`, unchanged.